### PR TITLE
Add DatabaseObject.executePreparedRetrieval() method

### DIFF
--- a/src/main/java/helma/scripting/rhino/extensions/DatabaseObject.java
+++ b/src/main/java/helma/scripting/rhino/extensions/DatabaseObject.java
@@ -216,6 +216,23 @@ public class DatabaseObject {
         }
     }
 
+    public RowSet executePreparedRetrieval(PreparedStatement statement) {
+        ResultSet resultSet = null;
+
+        try {
+            resultSet = statement.executeQuery();
+            return new RowSet(statement.toString(), this, statement, resultSet);
+        } catch (SQLException e) {
+            lastError = e;
+            try {
+                if (statement != null) statement.close();
+            } catch (Exception ignored) {
+            }
+            statement = null;
+            return null;
+        }
+    }
+
     public int executeCommand(String sql) {
         int count = 0;
 


### PR DESCRIPTION
Example code:

```js
const sql = 'select * from foo where bar = ?';
const db = getDBConnection('foobar');
const connection = db.getMetaData().getConnection();
const statement = connection.prepareStatement(sql);
statement.setInt(1, 23);
const rows = db.executePreparedRetrieval(statement);
// Resulting SQL query: select * from foo where bar = 23;
```
