### PR TITLE
Rewrite `for…each` with `for…of`

### DIFF
--- a/modules/jala/code/Database.js
+++ b/modules/jala/code/Database.js
@@ -518,7 +518,7 @@ jala.db.DataType = function(type, typeName, params) {
    this.getParams = function() {
       return params;
    };
-   
+
    /** @ignore */
    this.toString = function() {
       return "[DataType " +
@@ -597,7 +597,7 @@ jala.db.RamDatabase = function(name, username, password) {
    this.getUsername = function() {
       return username || "sa";
    };
-   
+
    /**
     * Returns the password of this database
     * @returns The password of this database
@@ -841,7 +841,7 @@ jala.db.RamDatabase.prototype.copyTables = function(database, tables) {
          tables = jala.db.metadata.getTableNames(dbMetadata);
       }
 
-      for each (var tableName in tables) {
+      for (let tableName of tables) {
          // drop the table if it exists
          if (this.tableExists(tableName)) {
             this.dropTable(tableName);
@@ -1011,7 +1011,7 @@ jala.db.FileDatabase = function(name, directory, username, password) {
    this.getUsername = function() {
       return username || "sa";
    };
-   
+
    /**
     * Returns the password of this database
     * @returns The password of this database

--- a/modules/jala/util/HopKit/scripts/MessageParser.js
+++ b/modules/jala/util/HopKit/scripts/MessageParser.js
@@ -330,7 +330,7 @@ MessageParser.prototype.parseSkinFile = function(file, encoding) {
   var processMacros = function(macros) {
     var re = gettext_macro.REGEX;
     var id, pluralId, name, args, param, key, msg;
-    for each (var macro in macros) {
+    for (let macro of macros) {
       id = pluralId = null;
       name = macro.getName();
       param = macro.getNamedParams();
@@ -374,7 +374,7 @@ MessageParser.prototype.parseSkinFile = function(file, encoding) {
   if (skin.hasMainskin()) {
     processMacros(skin.getMacros());
   }
-  for each (var name in skin.getSubskinNames()) {
+  for (let name of skin.getSubskinNames()) {
     var subskin = skin.getSubskin(name);
     processMacros(subskin.getMacros());
   }

--- a/modules/jala/util/Test/code/Global/jala.Test.js
+++ b/modules/jala/util/Test/code/Global/jala.Test.js
@@ -41,7 +41,7 @@ app.addRepository("modules/helma/Http.js");
 /**
  * Jala dependencies
  */
-app.addRepository(getProperty("jala.dir", "modules/jala") + 
+app.addRepository(getProperty("jala.dir", "modules/jala") +
                   "/code/Database.js");
 
 /**
@@ -573,11 +573,11 @@ jala.Test.prototype.executeTest = function(testFile) {
    } finally {
       // exit the js context created above
       cx.exit();
-      // FIXME (sim) don't polute global in the first place or 
+      // FIXME (sim) don't polute global in the first place or
       //             get a fresh global for each testrun
       global.testFunctionIdents.forEach(function(funcName) {
          // NOTE won't work on var-defined props
-         // delete global[funcName]] 
+         // delete global[funcName]]
          global[funcName] = "ignoreMe";
       }, this);
       global["setup"] = "ignoreMe";
@@ -861,7 +861,7 @@ jala.Test.prototype.assertEqualFile = function assertEqualFile(val, file) {
       // the last linefeed in a file too
       var str = value1.replace(/\r?\n$/g, "");
       equals = str === file.readAll();
-   }      
+   }
    if (!equals) {
       throw new jala.Test.TestException(comment,
                       "Expected " + jala.Test.valueToString(value1) +
@@ -1155,7 +1155,7 @@ jala.Test.HttpClient = function() {
    this.getClient = function() {
       return client;
    };
-   
+
    /**
     * Sets the cookie to use for subsequent requests using this client
     * @param {Array} arr The cookie object as received from helma.Http.getUrl
@@ -1336,7 +1336,7 @@ jala.Test.DatabaseMgr.prototype.startDatabase = function(dbSourceName, copyTable
             // collect the table names of all relational prototypes
             tables = [];
             var protos = app.getPrototypes();
-            for each (var proto in protos) {
+            for (let proto of protos) {
                var dbMap = proto.getDbMapping();
                if (dbMap.isRelational()) {
                   tables.push(dbMap.getTableName());
@@ -1401,7 +1401,7 @@ jala.Test.DatabaseMgr.prototype.stopAll = function() {
  */
 jala.Test.SmtpServer = function(port) {
    var server = null;
-   
+
    var oldSmtpServer = null;
 
    /**

--- a/src/dist/apps/test/tests/HopObjectCollection.js
+++ b/src/dist/apps/test/tests/HopObjectCollection.js
@@ -149,7 +149,7 @@ function testOrder(org, pos) {
 
 function cleanup() {
     var persons = root.persons.list();
-    for each (var person in persons) {
+    for (let person of persons) {
         person.remove();
     }
     ikea.remove();

--- a/src/dist/apps/test/tests/HopObjectGeneric.js
+++ b/src/dist/apps/test/tests/HopObjectGeneric.js
@@ -86,7 +86,7 @@ function testAdd() {
 
 function cleanup() {
     var persons = org.generic.list();
-    for each (var person in persons) {
+    for (let person of persons) {
         person.remove();
     }
     org.remove();

--- a/src/dist/apps/test/tests/HopObjectGroupBy.js
+++ b/src/dist/apps/test/tests/HopObjectGroupBy.js
@@ -68,7 +68,7 @@ function testGroupByAddRemoveNoCommit() {
    // FIXME HELMABUG: country is still accessible at this point
    // similar to http://helma.org/bugs/show_bug.cgi?id=551
    assertNull(root.organisationsByCountry.get(org.country));
-   
+
    assertEqual(countryCount, root.organisationsByCountry.count());
 }
 
@@ -130,7 +130,7 @@ function testGroupTransient() {
    assertNotNull(country);
    assertEqual(country._prototype, "Country");
    assertEqual(country.groupname, org.country);
-   
+
    // These don't work as org uses the parent from type.properties
    // which is root.organisations. Not sure if this is a bug or not.
    // assertEqual(country, org._parent);
@@ -143,7 +143,7 @@ function testGroupTransient() {
 
 function cleanup() {
     var orgs = root.organisations.list();
-    for each (var org in orgs) {
+    for (let org of orgs) {
         org.remove();
     }
 }

--- a/src/main/java/helma/scripting/rhino/RhinoCore.java
+++ b/src/main/java/helma/scripting/rhino/RhinoCore.java
@@ -93,8 +93,8 @@ public final class RhinoCore implements ScopeProvider {
     // optimization level for rhino engine, ranges from -1 to 9
     int optLevel = 0;
 
-    // language version - default to JS 1.8
-    int languageVersion = 180;
+    // language version - default to ES6
+    int languageVersion = 200;
 
     // debugger/tracer flags
     boolean hasDebugger = false;


### PR DESCRIPTION
Rhino’s `for…each` loop is a non-standard JavaScript extension and causing some problems, e.g. with JSDoc.

Rewriting it is quite straight-forward, either by using the `for…of` loop, the `Array.forEach()` method, or the good old `for…in` syntax:

> :bulb: For the `for…of` loop to work, the `VERSION_ES6` flag must be enabled in Rhino!

```js
var collection = [1, 2, 3];

// Rhino-specific for…each loop
for each (let value in collection) {
  console.log(value);
}

// for…of loop
for (let value of collection) {
  console.log(value);
}

// Array.forEach method
collection.forEach(value => console.log(value));

collection = {a: 1, b: 2, c: 3};

// for…in loop – Rhino does not support `Object.values()`
for (let key in collection) {
  let value = collection[key];
  console.log(value);
}
```
