### PR TITLE
Fix JavaDoc warnings

### DIFF
--- a/src/main/java/helma/framework/ResponseBean.java
+++ b/src/main/java/helma/framework/ResponseBean.java
@@ -280,9 +280,9 @@ public class ResponseBean implements Serializable {
     }
 
     /**
-     * add an HTML formatted debug message to the end of the page.
+     * add HTML formatted debug messages to the end of the page.
      *
-     * @param message the message
+     * @param messages the list of messages
      */
     public void debug(String... messages) {
         if (messages == null) {

--- a/src/main/java/helma/framework/ResponseTrans.java
+++ b/src/main/java/helma/framework/ResponseTrans.java
@@ -384,7 +384,7 @@ public final class ResponseTrans extends Writer implements Serializable {
     }
 
     /**
-     * Replace special characters with entities, including <, > and ", thus allowing
+     * Replace special characters with entities, including {@code <}, {@code >} and {@code "}, thus allowing
      * no HTML tags.
      */
     public synchronized void encode(Object what) {
@@ -415,7 +415,7 @@ public final class ResponseTrans extends Writer implements Serializable {
     }
 
     /**
-     * Replace special characters with entities, including <, > and ", thus allowing
+     * Replace special characters with entities, including {@code <}, {@code >} and {@code "}, thus allowing
      * no HTML tags.
      */
     public synchronized void encodeXml(Object what) {

--- a/src/main/java/helma/image/ImageWrapper.java
+++ b/src/main/java/helma/image/ImageWrapper.java
@@ -16,21 +16,21 @@
 
 /*
  * A few explanations:
- * 
+ *
  * - this.image is either an AWT Image or a BufferedImage.
  *   It depends on the ImageGenerator in what form the Image initially is.
  *   (the ImageIO implementation only uses BufferedImages for example.)
- * 
- *   As soon as some action that needs the graphics object is performed and the  
+ *
+ *   As soon as some action that needs the graphics object is performed and the
  *   image is still in AWT format, it is converted to a BufferedImage
- * 
+ *
  *   Any internal function that performs graphical actions needs to call
  *   getGraphics, never rely on this.graphics being set correctly!
- * 
+ *
  * - ImageWrapper objects are created and safed by the ImageGenerator class
  *   all different implementations of Imaging functionallity are implemented
  *   as a ImageGenerator extending class.
- * 
+ *
  */
 
 package helma.image;
@@ -52,7 +52,7 @@ public class ImageWrapper {
 
     /**
      * Creates a new ImageWrapper object.
-     * 
+     *
      * @param image ...
      * @param width ...
      * @param height ...
@@ -66,7 +66,7 @@ public class ImageWrapper {
         // graphics are turned off by default. getGraphics activates it if necessary.
         this.graphics = null;
     }
-    
+
     public ImageWrapper(Image image, ImageGenerator generator) {
         this(image, image.getWidth(null), image.getHeight(null), generator);
     }
@@ -78,7 +78,7 @@ public class ImageWrapper {
      * not. By using getBufferedImage, images are only converted to a
      * getBufferedImage when this is actually needed, which is better than
      * storing images as BufferedImage in general.
-     * 
+     *
      * @return the Image object as a BufferedImage
      */
     public BufferedImage getBufferedImage() {
@@ -94,9 +94,9 @@ public class ImageWrapper {
     }
 
     /**
-     * Returns the Graphics object to directly paint to this Image. Converts the 
+     * Returns the Graphics object to directly paint to this Image. Converts the
      * internal image to a BufferedImage if necessary.
-     * 
+     *
      * @return the Graphics object for drawing into this image
      */
     public Graphics2D getGraphics() {
@@ -107,7 +107,7 @@ public class ImageWrapper {
         }
         return graphics;
     }
-    
+
     /**
      * Sets the internal image and clears the stored graphics object.
      * Any code that is changing the internal image should do it through this function
@@ -129,7 +129,7 @@ public class ImageWrapper {
 
     /**
      * Creates and returns a copy of this image.
-     * 
+     *
      * @return a clone of this image.
      */
     public Object clone() {
@@ -141,7 +141,7 @@ public class ImageWrapper {
 
     /**
      * Returns the Image object represented by this ImageWrapper.
-     * 
+     *
      * @return the image object
      */
     public Image getImage() {
@@ -150,7 +150,7 @@ public class ImageWrapper {
 
     /**
      * Returns the ImageProducer of the wrapped image
-     * 
+     *
      * @return the images's ImageProducer
      */
     public ImageProducer getSource() {
@@ -180,7 +180,7 @@ public class ImageWrapper {
 
     /**
      * Sets the color used to write/paint to this image.
-     * 
+     *
      * @param red ...
      * @param green ...
      * @param blue ...
@@ -191,7 +191,7 @@ public class ImageWrapper {
 
     /**
      * Sets the color used to write/paint to this image.
-     * 
+     *
      * @param color ...
      */
     public void setColor(int color) {
@@ -200,7 +200,7 @@ public class ImageWrapper {
 
     /**
      * Sets the color used to write/paint to this image.
-     * 
+     *
      * @param color ...
      */
     public void setColor(Color color) {
@@ -209,7 +209,7 @@ public class ImageWrapper {
 
     /**
      * Sets the color used to write/paint to this image.
-     * 
+     *
      * @param color ...
      */
     public void setColor(String color) {
@@ -217,7 +217,7 @@ public class ImageWrapper {
     }
     /**
      * Draws a string to this image at the given coordinates.
-     * 
+     *
      * @param str ...
      * @param x ...
      * @param y ...
@@ -228,7 +228,7 @@ public class ImageWrapper {
 
     /**
      * Draws a line to this image from x1/y1 to x2/y2.
-     * 
+     *
      * @param x1 ...
      * @param y1 ...
      * @param x2 ...
@@ -240,7 +240,7 @@ public class ImageWrapper {
 
     /**
      * Draws a rectangle to this image.
-     * 
+     *
      * @param x ...
      * @param y ...
      * @param w ...
@@ -252,12 +252,12 @@ public class ImageWrapper {
 
     /**
      * Draws another image to this image.
-     * 
+     *
      * @param filename ...
      * @param x ...
      * @param y ...
      */
-    public void drawImage(String filename, int x, int y) 
+    public void drawImage(String filename, int x, int y)
         throws IOException {
         Image img = generator.read(filename);
         if (img != null)
@@ -266,30 +266,30 @@ public class ImageWrapper {
 
     /**
      * Draws another image to this image.
-     * 
+     *
      * @param image ...
      * @param x ...
      * @param y ...
      */
-    public void drawImage(ImageWrapper image, int x, int y) 
+    public void drawImage(ImageWrapper image, int x, int y)
         throws IOException {
         getGraphics().drawImage(image.getImage(), x, y, null);
     }
 
     /**
      * Draws another image to this image.
-     * 
+     *
      * @param image ...
      * @param at ...
      */
-    public void drawImage(ImageWrapper image, AffineTransform at) 
+    public void drawImage(ImageWrapper image, AffineTransform at)
         throws IOException {
         getGraphics().drawImage(image.getImage(), at, null);
     }
 
     /**
      * Draws a filled rectangle to this image.
-     * 
+     *
      * @param x ...
      * @param y ...
      * @param w ...
@@ -301,7 +301,7 @@ public class ImageWrapper {
 
     /**
      * Returns the width of this image.
-     * 
+     *
      * @return the width of this image
      */
     public int getWidth() {
@@ -310,7 +310,7 @@ public class ImageWrapper {
 
     /**
      * Returns the height of this image.
-     * 
+     *
      * @return the height of this image
      */
     public int getHeight() {
@@ -319,7 +319,7 @@ public class ImageWrapper {
 
     /**
      * Crops the image.
-     * 
+     *
      * @param x ...
      * @param y ...
      * @param w ...
@@ -340,21 +340,21 @@ public class ImageWrapper {
             setImage(buffered);
         }
     }
-    
+
     /**
      * Trims the image.
-     * 
+     *
      * @param x the x-coordinate of the pixel specifying the background color
      * @param y the y-coordinate of the pixel specifying the background color
      */
-    
+
    public void trim(int x, int y) {
        trim(x, y, true, true, true, true);
    }
 
    /**
     * Trims the image.
-    * 
+    *
     * @param x
     * @param y
     * @param trimLeft
@@ -369,7 +369,7 @@ public class ImageWrapper {
 
         // create a BufferedImage of only 1 pixel height for fetching the rows of the image in the correct format (ARGB)
         // This speeds up things by more than factor 2, compared to the standard BufferedImage.getRGB solution,
-        // which is supposed to be fast too. This is probably the case because drawing to BufferedImages uses 
+        // which is supposed to be fast too. This is probably the case because drawing to BufferedImages uses
         // very optimized code which may even be hardware accelerated.
         if (trimTop || trimBottom) {
             BufferedImage row = new BufferedImage(width, 1, BufferedImage.TYPE_INT_ARGB);
@@ -445,7 +445,7 @@ public class ImageWrapper {
         }
         crop(left, top, right - left + 1, bottom - top + 1);
     }
-    
+
     /**
      * Resizes the image using the Graphics2D approach
      */
@@ -453,12 +453,12 @@ public class ImageWrapper {
         BufferedImage buffered = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
         Graphics2D g2d = buffered.createGraphics();
 
-        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, 
+        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
             smooth ? RenderingHints.VALUE_INTERPOLATION_BICUBIC :
                 RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR
         );
 
-        g2d.setRenderingHint(RenderingHints.KEY_RENDERING, 
+        g2d.setRenderingHint(RenderingHints.KEY_RENDERING,
             smooth ? RenderingHints.VALUE_RENDER_QUALITY :
                 RenderingHints.VALUE_RENDER_SPEED
         );
@@ -474,7 +474,7 @@ public class ImageWrapper {
 
     /**
      * Resizes the image
-     * 
+     *
      * @param w ...
      * @param h ...
      */
@@ -494,7 +494,7 @@ public class ImageWrapper {
             // Image scaled = ImageWaiter.waitForImage(image.getScaledInstance(w, h, Image.SCALE_AREA_AVERAGING));
             // if (scaled == null)
             //     throw new RuntimeException("Image cannot be resized.");
-            
+
             // This version is up to 4 times faster than getScaledInstance:
             ImageFilterOp filter = new ImageFilterOp(new AreaAveragingScaleFilter(w, h));
             setImage(filter.filter(getBufferedImage(), null));
@@ -503,7 +503,7 @@ public class ImageWrapper {
 
     /**
      * Resize the image, using a fast and cheap algorithm
-     * 
+     *
      * @param w ...
      * @param h ...
      */
@@ -513,8 +513,8 @@ public class ImageWrapper {
 
     /**
      * Reduces the colors used in the image. Necessary before saving as GIF.
-     * 
-     * @param colors colors the number of colors to use, usually <= 256.
+     *
+     * @param colors colors the number of colors to use, usually {@literal <}= 256.
      */
     public void reduceColors(int colors) {
         reduceColors(colors, false);
@@ -522,8 +522,8 @@ public class ImageWrapper {
 
     /**
      * Reduces the colors used in the image. Necessary before saving as GIF.
-     * 
-     * @param colors colors the number of colors to use, usually <= 256.
+     *
+     * @param colors colors the number of colors to use, usually {@literal <}= 256.
      * @param dither ...
      */
     public void reduceColors(int colors, boolean dither) {
@@ -533,8 +533,8 @@ public class ImageWrapper {
     /**
      * Reduce the colors used in this image. Useful and necessary before saving
      * the image as GIF file.
-     * 
-     * @param colors the number of colors to use, usually <= 256.
+     *
+     * @param colors the number of colors to use, usually {@literal <}= 256.
      * @param dither ...
      * @param alphaToBitmask ...
      */
@@ -546,7 +546,7 @@ public class ImageWrapper {
 
     /**
      * Save the image. Image format is deduced from filename.
-     * 
+     *
      * @param filename ...
      * @throws IOException
      */
@@ -557,7 +557,7 @@ public class ImageWrapper {
 
     /**
      * Saves the image. Image format is deduced from filename.
-     * 
+     *
      * @param filename ...
      * @param quality ...
      * @throws IOException
@@ -569,7 +569,7 @@ public class ImageWrapper {
 
     /**
      * Saves the image. Image format is deduced from filename.
-     * 
+     *
      * @param filename ...
      * @param quality ...
      * @param alpha ...
@@ -579,10 +579,10 @@ public class ImageWrapper {
         throws IOException {
         generator.write(this, checkFilename(filename), quality, alpha);
     }
-    
+
     /**
      * Saves the image. Image format is deduced from mimeType.
-     * 
+     *
      * @param out ...
      * @param mimeType ...
      * @throws IOException
@@ -591,10 +591,10 @@ public class ImageWrapper {
         throws IOException {
         generator.write(this, out, mimeType, -1f, false); // -1 means default quality
     }
-    
+
     /**
      * Saves the image. Image format is deduced from mimeType.
-     * 
+     *
      * @param out ...
      * @param mimeType ...
      * @param quality ...
@@ -607,7 +607,7 @@ public class ImageWrapper {
 
     /**
      * Saves the image. Image format is deduced from mimeType.
-     * 
+     *
      * @param out ...
      * @param mimeType ...
      * @param quality ...
@@ -618,7 +618,7 @@ public class ImageWrapper {
         throws IOException {
         generator.write(this, out, mimeType, quality, alpha);
     }
-    
+
     /**
      * Sets the palette index of the transparent color for Images with an
      * IndexColorModel. This can be used together with
@@ -648,7 +648,7 @@ public class ImageWrapper {
     /**
      * Returns the pixel at x, y. If the image is indexed, it returns the
      * palette index, otherwise the rgb code of the color is returned.
-     * 
+     *
      * @param x the x coordinate of the pixel
      * @param y the y coordinate of the pixel
      * @return the pixel at x, y

--- a/src/main/java/helma/servlet/AbstractServletClient.java
+++ b/src/main/java/helma/servlet/AbstractServletClient.java
@@ -753,7 +753,7 @@ public abstract class AbstractServletClient extends HttpServlet {
      * <strong>IMPLEMENTATION NOTE</strong>:  URL decoding is performed
      * individually on the parsed name and value elements, rather than on
      * the entire query string ahead of time, to properly deal with the case
-     * where the name or value includes an encoded "=" or "&" character
+     * where the name or value includes an encoded {@code =} or {@code &} character
      * that would otherwise be interpreted as a delimiter.
      *
      * NOTE: byte array data is modified by this method.  Caller beware.

--- a/src/main/java/helma/util/HtmlEncoder.java
+++ b/src/main/java/helma/util/HtmlEncoder.java
@@ -127,7 +127,7 @@ public final class HtmlEncoder {
     /**
      *  Do "smart" encodging on a string. This means that valid HTML entities and tags,
      *  Helma macros and HTML comments are passed through unescaped, while
-     *  other occurrences of '<', '>' and '&' are encoded to HTML entities.
+     *  other occurrences of {@code <}, {@code >} and {@code &} are encoded to HTML entities.
      */
     public final static String encode(String str) {
         if (str == null) {
@@ -151,7 +151,7 @@ public final class HtmlEncoder {
     /**
      *  Do "smart" encodging on a string. This means that valid HTML entities and tags,
      *  Helma macros and HTML comments are passed through unescaped, while
-     *  other occurrences of '<', '>' and '&' are encoded to HTML entities.
+     *  other occurrences of {@code <}, {@code >} and {@code &} are encoded to HTML entities.
      */
     public final static void encode(String str, StringBuffer ret) {
         encode(str, ret, false, null);
@@ -160,7 +160,7 @@ public final class HtmlEncoder {
     /**
      *  Do "smart" encodging on a string. This means that valid HTML entities and tags,
      *  Helma macros and HTML comments are passed through unescaped, while
-     *  other occurrences of '<', '>' and '&' are encoded to HTML entities.
+     *  other occurrences of {@code <}, {@code >} and {@code &} are encoded to HTML entities.
      *
      *  @param str the string to encode
      *  @param ret the string buffer to encode to


### PR DESCRIPTION
Mostly HTML entity / encoding issues resolved by applying `{@code}` or `{@literal}`.